### PR TITLE
Point interested users at the Freeciv21 client

### DIFF
--- a/templates/intro.html
+++ b/templates/intro.html
@@ -21,7 +21,7 @@ Fourthly, and for me this is the most important aspect of Longturn, diplomacy is
 <h2>How to join</h2>
 <p>
 Longturn.net games are starting a few times per year in roughly regular intervals, although there is no rule. They are announced well ahead and registrations are usually open roughly a month ahead. To play a Longturn.net game you need to do three things:
-<p> 1. Install a Freeciv native client. This can be found at <href=http://freeciv.org>Freeciv.org</a>. Usually a game will be run on the newest version of server/client, but not always (for various reasons). Sometimes you may need to download and install an older version of the client. Older versions of Freeciv are also available on the Download page of Freeciv.org. Information about which Freeciv version is required for a particular LT game should be readily available on the game page (top right).
+<p> 1. Install the Freeciv21 client. This can be found at <href=https://github.com/longturn/freeciv21/releases>. Usually a game will be run on the latest stable version of server/client. Information about which Freeciv21 version is required for a particular LT game should be readily available on the game page (top right).
 <p> 2. Register at Longturn.net (this site).
 <p> 3. Sign up for the game when registrations are open <b>AND</b> confirm participation a few days before it actually starts. You need to do <b>BOTH</b> otherwise you will not be able to play the game. This is a measure to reduce the amount of idler as much as possible.
 <h2>History of Longturn</h2>

--- a/templates/intro.html
+++ b/templates/intro.html
@@ -21,7 +21,7 @@ Fourthly, and for me this is the most important aspect of Longturn, diplomacy is
 <h2>How to join</h2>
 <p>
 Longturn.net games are starting a few times per year in roughly regular intervals, although there is no rule. They are announced well ahead and registrations are usually open roughly a month ahead. To play a Longturn.net game you need to do three things:
-<p> 1. Install the Freeciv21 client. This can be found at <href=https://github.com/longturn/freeciv21/releases>. Usually a game will be run on the latest stable version of server/client. Information about which Freeciv21 version is required for a particular LT game should be readily available on the game page (top right).
+<p> 1. Install Freeciv21. This can be found on <a href=https://github.com/longturn/freeciv21/releases>GitHub</a>. Games are run on the latest stable release, however you can also play with the latest unstable release.
 <p> 2. Register at Longturn.net (this site).
 <p> 3. Sign up for the game when registrations are open <b>AND</b> confirm participation a few days before it actually starts. You need to do <b>BOTH</b> otherwise you will not be able to play the game. This is a measure to reduce the amount of idler as much as possible.
 <h2>History of Longturn</h2>


### PR DESCRIPTION
Update "Introduction to Longturn" to tell interested users to install the Freeciv21 client and where to find it.

Remove the confusing references to possibly required, outdated client versions.

Context: https://discord.com/channels/378908274113904641/569316734667063297/1209958910031568917